### PR TITLE
Make shellcheck changes

### DIFF
--- a/create_keys.sh
+++ b/create_keys.sh
@@ -9,13 +9,12 @@ else
     DIR=.
 fi
 
-for i in `seq 1 10`; do
+for i in $(seq 1 10); do
     uuid=$(uuidgen)
 
     pub=es256_$uuid.pem
     priv=es256_$uuid-priv.pem
 
-    openssl ecparam -name secp256k1 -genkey -noout -out $DIR/keys/$priv 
-    openssl ec -in $DIR/keys/$priv -pubout -out $DIR/keys/$pub
-
+    openssl ecparam -name secp256k1 -genkey -noout -out "$DIR/keys/$priv"
+    openssl ec -in "$DIR/keys/$priv" -pubout -out "$DIR/keys/$pub"
 done


### PR DESCRIPTION
* Main purpose: Secure the `create_keys.sh` script a bit
 
* Technical description: Use up-to-date syntax for `seq` and wrap the openssl args in quotes to enforce string interpolation

* Dilemmas you faced with? N/A

* Tests N/A

* Documentation (Source/readme.md)