### PR TITLE
Add more ignores to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,10 @@ examples/
 .git*
 .idea/
 .tags
+tags
+.vscode
+create_keys.sh
+node_modules/
 **/*.js
 __pycache__/
 Dockerfile


### PR DESCRIPTION
* Main purpose: Tell Docker to ignore unnecessary files
 
* Technical description: Adds ignores for files generated by `npm` as well as other utils specified in the repo that Docker will not require for building an image.

* Dilemmas you faced with? None

* Tests

* Documentation (Source/readme.md)